### PR TITLE
hide original player element

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Twitch Adblock
 // @namespace    https://greasyfork.org/en/users/9694-croned
-// @version      1.3.9
+// @version      1.3.10
 // @description  [Working as of 11/19/2020] Blocks Twitch livestream ads
 // @author       FTwitch
 // @include      https://www.twitch.tv/*
@@ -209,6 +209,9 @@ const compressor_on = 'M850 200C877.7 200 900 222.3 900 250V750C900 777.7 877.7 
                                 clearInterval(quality);
                             }
                         }, 1000);
+
+                        // Finally, hide original player element
+                        el.style.display = "none";
 
                         return true;
                     }


### PR DESCRIPTION
Hides the original player so we aren't rendering a node that we aren't using. Tested with FF `83.0` and I was still able to receive channel points, so the player element still emits events.

Not tested on chrome/brave